### PR TITLE
fix: Reverting use of ubuntu:16 breaks concourse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,20 @@
-FROM ubuntu:16.04
-LABEL org.opencontainers.image.authors="Unif.io, Inc. <support@unif.io>"
-LABEL org.opencontainers.image.source="https://github.com/unifio/dockerfile-concourse-consul"
-VOLUME /concourse-keys
-ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key_pub
-ENV CONCOURSE_TSA_HOST_KEY            /concourse-keys/tsa_host_key
-ENV CONCOURSE_TSA_AUTHORIZED_KEYS     /concourse-keys/authorized_worker_keys
-ENV CONCOURSE_SESSION_SIGNING_KEY     /concourse-keys/session_signing_key
-ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key_pub
-ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY  /concourse-keys/worker_key
-ENV CONCOURSE_WORK_DIR                /worker-state
+FROM concourse/concourse:2.5.0
+MAINTAINER Unif.io, Inc. <support@unif.io>
+
+ENV CONCOURSE_TSA_PUBLIC_KEY         /concourse-keys/tsa_host_key_pub
 
 ENV ENVCONSUL_VERSION=0.6.1
 ENV CONSULTEMPLATE_VERSION=0.16.0
-ENV CONCOURSE_VERSION=2.5.0
-ENV DUMB_INIT_VERSION=1.2.5
 
 RUN apt-get update && \
-    apt-get install -y iproute2 ca-certificates curl wget unzip && \
+    apt-get -y upgrade ca-certificates curl unzip && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
-    curl -Ls --output /usr/local/bin/concourse https://github.com/concourse/concourse/releases/download/v${CONCOURSE_VERSION}/concourse_linux_amd64 && \
-    chmod a+x /usr/local/bin/concourse && \
-    curl -Ls --output dumb-init.deb https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64.deb && \
-    dpkg -i dumb-init.deb && \
-    curl -Ls --output envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION}/envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip && \
-    curl -Ls --output envconsul_${ENVCONSUL_VERSION}_SHA256SUMS https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION}/envconsul_${ENVCONSUL_VERSION}_SHA256SUMS && \
-    curl -Ls --output envconsul_${ENVCONSUL_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION}/envconsul_${ENVCONSUL_VERSION}_SHA256SUMS.sig && \
-    curl -Ls --output consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip && \
-    curl -Ls --output consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS && \
+    curl -s --output envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION}/envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip && \
+    curl -s --output envconsul_${ENVCONSUL_VERSION}_SHA256SUMS https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION}/envconsul_${ENVCONSUL_VERSION}_SHA256SUMS && \
+    curl -s --output envconsul_${ENVCONSUL_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/envconsul/${ENVCONSUL_VERSION}/envconsul_${ENVCONSUL_VERSION}_SHA256SUMS.sig && \
+    curl -s --output consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip && \
+    curl -s --output consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS && \
     curl -s --output consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/consul-template/${CONSULTEMPLATE_VERSION}/consul-template_${CONSULTEMPLATE_VERSION}_SHA256SUMS.sig && \
     gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
     gpg --batch --verify envconsul_${ENVCONSUL_VERSION}_SHA256SUMS.sig envconsul_${ENVCONSUL_VERSION}_SHA256SUMS && \
@@ -37,10 +24,8 @@ RUN apt-get update && \
     unzip -d /usr/local/bin envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip && \
     unzip -d /usr/local/bin consul-template_${CONSULTEMPLATE_VERSION}_linux_amd64.zip && \
     cd /tmp && \
-    rm -rf /tmp/build && \
-    apt-get autoremove -y && \
-    apt-get clean
+    rm -rf /tmp/build
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-ENTRYPOINT ["/usr/bin/dumb-init", "/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
* Going back to just updating the ca-certificates. Doing any other updates seems to break concourse binary from running. Something else that apt was updating breaks it for some reason.